### PR TITLE
fix method AuthenticationService::authenticateUser() when parameter $…

### DIFF
--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -28,12 +28,14 @@ class AuthenticationService
      * @param string $username
      * @param string $password
      * @param string|null $baseDn
+     * @param int $ldapSearchScope
+     *            (default value: \Zend\Ldap\Ldap::SEARCH_SCOPE_ONE)
      *
      * @return User
      * @throws AuthenticationException
      *
      */
-    public function authenticateUser(string $username, string $password, string $baseDn = null): User
+    public function authenticateUser(string $username, string $password, string $baseDn = null, $ldapSearchScope = Ldap::SEARCH_SCOPE_ONE): User
     {
         $filters = new AndFilter([
             'objectclass=user',
@@ -52,7 +54,7 @@ class AuthenticationService
                 ]));
             }
 
-            $users = $this->ldapConnection->search($filters, $baseDn, Ldap::SEARCH_SCOPE_ONE);
+            $users = $this->ldapConnection->search($filters, $baseDn, $ldapSearchScope);
 
             $this->ldapConnection->bind($users->dn(), $password);
             $user = $this->ldapConnection->getEntry($this->ldapConnection->getBoundUser());

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -46,9 +46,11 @@ class AuthenticationService
         ]);
 
         try {
-            $this->ldapConnection->setOptions([
-                'baseDn' => $baseDn
-            ]);
+            if ($baseDn !== null) {
+                $this->ldapConnection->setOptions([
+                    'baseDn' => $baseDn
+                ]);
+            }
 
             $users = $this->ldapConnection->search($filters, $baseDn, Ldap::SEARCH_SCOPE_ONE);
 

--- a/src/AuthenticationService.php
+++ b/src/AuthenticationService.php
@@ -47,9 +47,9 @@ class AuthenticationService
 
         try {
             if ($baseDn !== null) {
-                $this->ldapConnection->setOptions([
+                $this->ldapConnection->setOptions(array_merge($this->ldapConnection->getOptions(), [
                     'baseDn' => $baseDn
-                ]);
+                ]));
             }
 
             $users = $this->ldapConnection->search($filters, $baseDn, Ldap::SEARCH_SCOPE_ONE);


### PR DESCRIPTION
…baseDn is not set

without this patch, authentification will always fail for sure.