### PR TITLE
Update laminas/laminas-ldap dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=7.2.0",
     "ext-json": "*",
     "ext-ldap": "*",
-    "firebase/php-jwt": "^5.0||^6.0",
+    "firebase/php-jwt": "^6.0",
     "laminas/laminas-ldap": "^2.10.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=7.2.0",
     "ext-json": "*",
     "ext-ldap": "*",
-    "firebase/php-jwt": "~5.0",
+    "firebase/php-jwt": "^5.0||^6.0",
     "laminas/laminas-ldap": "^2.10.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-ldap": "*",
     "firebase/php-jwt": "~5.0",
-    "laminas/laminas-ldap": "~2.10.3"
+    "laminas/laminas-ldap": "~2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-json": "*",
     "ext-ldap": "*",
     "firebase/php-jwt": "~5.0",
-    "laminas/laminas-ldap": "~2.0"
+    "laminas/laminas-ldap": "^2.10.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1"

--- a/src/JWTTokensService.php
+++ b/src/JWTTokensService.php
@@ -52,7 +52,7 @@ class JWTTokensService
      */
     public function encode(Claims $claims): string
     {
-        return JWT::encode($claims, $this->encodeKey, $this->algorithm);
+        return JWT::encode($claims->toArray(), $this->encodeKey, $this->algorithm);
     }
 
     /**

--- a/src/JWTTokensService.php
+++ b/src/JWTTokensService.php
@@ -3,6 +3,7 @@
 namespace P4BGroup\Authentication;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Throwable;
 
 class JWTTokensService
@@ -57,15 +58,14 @@ class JWTTokensService
 
     /**
      * @param string $token
-     * @param array|null $allowedAlgs
      *
      * @return Claims
      * @throws DecodeException
      */
-    public function decode(string $token, ?array $allowedAlgs = null): Claims
+    public function decode(string $token): Claims
     {
         try {
-            $rawClaims = JWT::decode($token, $this->decodeKey, $allowedAlgs ?? array_keys(JWT::$supported_algs));
+            $rawClaims = JWT::decode($token, new Key($this->decodeKey, $this->algorithm));
         } catch (Throwable $exception) {
             throw new DecodeException('UNABLE_TO_DECODE', 400, $exception);
         }


### PR DESCRIPTION
Laminas-ldap 2.10.3 only supports PHP < 8.0, so ldap-jwt-authentication cannot be deployed using PHP 8.1 and current laminas-ldap dependency.

Project laminas/laminas-ldap has merged all necessary [php 8.1 compatibility fixes](https://github.com/laminas/laminas-ldap/pull/27) into version 2.13.0